### PR TITLE
ci: bump cosign CLI from v2.2.4 to v3.0.6

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 #v4.1.1
         with:
-          cosign-release: 'v2.2.4'
+          cosign-release: 'v3.0.6'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache


### PR DESCRIPTION
## Summary

Bumps the pinned `cosign-release` in the publish workflow from **v2.2.4** (March 2024) to **v3.0.6** (April 2026, current stable).

The `cosign-installer` action itself has been kept up-to-date by Dependabot (currently `@4.1.1`), but the CLI version it installs is a string input, not a dependency-graph entry, so Dependabot never bumped it. Result: the CLI binary had been frozen for two years while the action around it kept moving.

The only use of cosign in this workflow is

```sh
echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
```

which is stable across v2.x → v3.x — no flags removed, no behaviour changes. This is a drop-in bump.

## Motivation

The `2026-04-10` scheduled build ([run 24239316209](https://github.com/enthus-appdev/github-actions-runner/actions/runs/24239316209)) failed at the Sign step with:

```
Error: signing [ghcr.io/.../github-actions-runner:main@sha256:c20921...]:
  getting signer: getting key from Fulcio:
  fetching ambient OIDC credentials:
  invalid character 'u' looking for beginning of value
```

Translation: cosign tried to fetch an OIDC token from the GitHub Actions token endpoint, got back a plain-text `unauthorized`-style response instead of JSON, and crashed parsing it. Both `:main` and `:nightly` signing failed in the same run; the next day's schedule (2026-04-11) recovered on its own, so the root cause was a transient GitHub OIDC hiccup.

Newer cosign releases have improved error handling and retry logic around exactly this class of Fulcio/OIDC token flake. Bumping the pin shouldn't eliminate GitHub flakes but should make the workflow resilient to them.

## Alternatives considered

- **Stay on v2.x, bump to `v2.6.3`** — the v2 line is still actively maintained (v2.6.3 released the same day as v3.0.6). This would be the most conservative bump and also addresses the flake. Skipped in favour of moving to the current major version since the CLI API used here is stable.
- **Add Dependabot tracking for the `cosign-release` string** — doesn't appear to be supported; Dependabot tracks declared dependencies, not arbitrary string inputs to actions. Manual bumps only.

## Test plan

- [ ] CI builds successfully on this PR (build & push only; sign step is skipped on PRs per `if: github.event_name != 'pull_request'`)
- [ ] After merge: verify the post-merge `push` run signs successfully with the new cosign version
- [ ] After merge: run `cosign verify` against the new `:main` digest using the tightened identity regexp from README.md to confirm signatures still verify end-to-end