### PR TITLE
feat: preinstall the GitHub CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM ghcr.io/actions/actions-runner:2.335.1
 
 # gh intentionally unpinned: like GitHub-hosted runners, the image tracks the latest CLI on each rebuild.
-# The keyring fingerprint check pins the apt trust anchor to GitHub's published signing key.
+# The fingerprint allowlist pins the apt trust anchor to exactly GitHub's published signing keys.
 RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
     sudo apt install -y curl wget rsync gnupg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
-    gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | grep -q '^fpr:::::::::2C6106201985B60E6C7AC87323F3D4EA75716059:' && \
-    [ "$(gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | grep -c '^pub:')" = 1 ] && \
+    [ "$(gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '/^pub/{getline; print $10}' | sort | tr '\n' ' ')" = "2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325 " ] && \
     sudo install -m 0644 /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     rm /tmp/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
     sudo apt install -y curl wget rsync gnupg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
-    # Fingerprints taken from the keyring served by cli.github.com on 2026-07-16, cross-checked
-    # against https://github.com/cli/cli/blob/trunk/docs/install_linux.md. A mismatch means
-    # GitHub rotated its packaging keys: re-verify against those docs and update the list.
+    # Primary-key fingerprints, trust-on-first-use from the keyring served by cli.github.com
+    # on 2026-07-16 (GitHub publishes only the keyring URL, not fingerprints). Detects future
+    # rotation/substitution, not a compromise of that initial download. On mismatch: re-fetch
+    # per https://github.com/cli/cli/blob/trunk/docs/install_linux.md and update the list.
     gnupgtmp="$(mktemp -d)" && \
     actual="$(GNUPGHOME=$gnupgtmp gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '$1=="pub"{p=1;next} p&&$1=="fpr"{print $10;p=0}' | LC_ALL=C sort | paste -sd' ')" && \
     rm -rf "$gnupgtmp" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
     sudo apt install -y curl wget rsync gnupg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
-    [ "$(gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '/^pub/{getline; print $10}' | sort | tr '\n' ' ')" = "2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325 " ] && \
+    # A mismatch below means GitHub rotated its packaging keys: re-verify against the official
+    # install docs (https://github.com/cli/cli/blob/trunk/docs/install_linux.md) and update the list.
+    actual="$(GNUPGHOME=$(mktemp -d) gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '$1=="pub"{p=1;next} p&&$1=="fpr"{print $10;p=0}' | sort | tr '\n' ' ')" && \
+    expected="2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325 " && \
+    { [ "$actual" = "$expected" ] || { echo "gh keyring fingerprint mismatch: got [$actual] want [$expected]" >&2; exit 1; }; } && \
     sudo install -m 0644 /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     rm /tmp/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt install -y curl wget rsync gnupg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
     gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | grep -q '^fpr:::::::::2C6106201985B60E6C7AC87323F3D4EA75716059:' && \
+    [ "$(gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | grep -c '^pub:')" = 1 ] && \
     sudo install -m 0644 /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     rm /tmp/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,9 @@ FROM ghcr.io/actions/actions-runner:2.335.1
 
 RUN sudo apt update -y && \
     sudo apt install -y curl wget rsync && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    sudo apt update -y && \
+    sudo apt install -y gh && \
     rm -rf /etc/apt/sources.list.d/temp.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
     sudo apt install -y curl wget rsync gnupg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
-    # A mismatch below means GitHub rotated its packaging keys: re-verify against the official
-    # install docs (https://github.com/cli/cli/blob/trunk/docs/install_linux.md) and update the list.
-    actual="$(GNUPGHOME=$(mktemp -d) gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '$1=="pub"{p=1;next} p&&$1=="fpr"{print $10;p=0}' | sort | tr '\n' ' ')" && \
-    expected="2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325 " && \
+    # Fingerprints taken from the keyring served by cli.github.com on 2026-07-16, cross-checked
+    # against https://github.com/cli/cli/blob/trunk/docs/install_linux.md. A mismatch means
+    # GitHub rotated its packaging keys: re-verify against those docs and update the list.
+    gnupgtmp="$(mktemp -d)" && \
+    actual="$(GNUPGHOME=$gnupgtmp gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '$1=="pub"{p=1;next} p&&$1=="fpr"{print $10;p=0}' | LC_ALL=C sort | paste -sd' ')" && \
+    rm -rf "$gnupgtmp" && \
+    expected="2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325" && \
     { [ "$actual" = "$expected" ] || { echo "gh keyring fingerprint mismatch: got [$actual] want [$expected]" >&2; exit 1; }; } && \
     sudo install -m 0644 /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     rm /tmp/githubcli-archive-keyring.gpg && \
@@ -17,4 +20,5 @@ RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
     sudo apt install -y gh && \
     gh --version && \
+    sudo apt clean && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM ghcr.io/actions/actions-runner:2.335.1
 
+# gh intentionally unpinned: like GitHub-hosted runners, the image tracks the latest CLI on each rebuild
 RUN sudo apt update -y && \
     sudo apt install -y curl wget rsync && \
+    sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
     sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     sudo apt update -y && \
     sudo apt install -y gh && \
-    rm -rf /etc/apt/sources.list.d/temp.list
+    sudo rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM ghcr.io/actions/actions-runner:2.335.1
 
-# gh intentionally unpinned: like GitHub-hosted runners, the image tracks the latest CLI on each rebuild
-RUN sudo apt update -y && \
-    sudo apt install -y curl wget rsync && \
-    sudo rm -rf /etc/apt/sources.list.d/temp.list && \
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg > /dev/null && \
-    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+# gh intentionally unpinned: like GitHub-hosted runners, the image tracks the latest CLI on each rebuild.
+# The keyring fingerprint check pins the apt trust anchor to GitHub's published signing key.
+RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
+    sudo apt update -y && \
+    sudo apt install -y curl wget rsync gnupg && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
+    gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | grep -q '^fpr:::::::::2C6106201985B60E6C7AC87323F3D4EA75716059:' && \
+    sudo install -m 0644 /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    rm /tmp/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     sudo apt update -y && \
     sudo apt install -y gh && \
+    gh --version && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     gnupgtmp="$(mktemp -d)" && \
     actual="$(GNUPGHOME=$gnupgtmp gpg --show-keys --with-colons /tmp/githubcli-archive-keyring.gpg | awk -F: '$1=="pub"{p=1;next} p&&$1=="fpr"{print $10;p=0}' | LC_ALL=C sort | paste -sd' ')" && \
     rm -rf "$gnupgtmp" && \
+    { [ -n "$actual" ] || { echo "gh keyring: no fingerprints extracted (download or gpg parse failed)" >&2; exit 1; }; } && \
     expected="2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325" && \
     { [ "$actual" = "$expected" ] || { echo "gh keyring fingerprint mismatch: got [$actual] want [$expected]" >&2; exit 1; }; } && \
     sudo install -m 0644 /tmp/githubcli-archive-keyring.gpg /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A self-hosted [GitHub Actions runner](https://docs.github.com/en/actions/hosting-your-own-runners) container image, built on top of the official [`ghcr.io/actions/actions-runner`](https://github.com/actions/runner/pkgs/container/actions-runner) image with a handful of everyday CLI tools preinstalled.
 
-The upstream runner image is intentionally minimal and does not ship `curl`, `wget`, or `rsync` — tools most real-world CI workflows expect to just be there. This image adds them so workflows don't have to `apt install` them on every run.
+The upstream runner image is intentionally minimal and does not ship `curl`, `wget`, `rsync`, or `gh` — tools most real-world CI workflows expect to just be there. This image adds them so workflows don't have to `apt install` them on every run.
 
 It is a drop-in replacement for the upstream image: anywhere `ghcr.io/actions/actions-runner` works, this image works.
 
@@ -16,6 +16,7 @@ Based on [`ghcr.io/actions/actions-runner`](https://github.com/actions/runner), 
 - `curl` — HTTP client
 - `wget` — HTTP/FTP downloader
 - `rsync` — fast file transfer and sync
+- `gh` — GitHub CLI (expected by actions such as `fgrosse/go-coverage-report`; preinstalled on GitHub-hosted runners)
 
 See [`Dockerfile`](Dockerfile) for the exact build definition.
 


### PR DESCRIPTION
## What & Why

When the ci-runner-router flipped `CI_RUNNER_DEFAULT` to `hetzner-ci-default` on 2026-07-16, negsoft-api's **Code coverage report** job started failing:

```
ERROR: Script requires "gh" (see https://cli.github.com)
```

`fgrosse/go-coverage-report` shells out to `gh`, which GitHub-hosted runners preinstall but this image doesn't. This adds `gh` from the official GitHub CLI apt repo, in the image's spirit of shipping the everyday tools workflows expect.

Example failing run: https://github.com/enthus-appdev/negsoft-api/actions/runs/29480616135 (job "Code coverage report")

## Rollout note

The ci-runners pod specs pull `:main` without `imagePullPolicy: Always`, so existing workers keep serving the cached image until they recycle (≤1h idle) or the pull policy is changed. New autoscaled workers pick the new image up immediately.

## Related

Same incident, sibling fixes: enthus-appdev/ci-runners#1 (golangci-lint cache mount) and an oss-actions PR adding setup-go to `go-license-validator`.