### PR TITLE
build: install libatomic1 in runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/actions/actions-runner:2.333.1
 
 RUN sudo apt update -y && \
-    sudo apt install -y curl wget rsync && \
+    sudo apt install -y curl wget rsync libatomic1 && \
     rm -rf /etc/apt/sources.list.d/temp.list


### PR DESCRIPTION
## Problem

Workflows routed onto these self-hosted runners (via [ci-runner-router](https://github.com/enthus-appdev/ci-runner-router)) that use `pnpm/action-setup` fail at the pnpm install step:

```
/home/runner/setup-pnpm/node_modules/@pnpm/exe/pnpm: error while loading
shared libraries: libatomic.so.1: cannot open shared object file
##[error]Something went wrong, self-installer exits with code 127
```

pnpm's precompiled standalone binary (`@pnpm/exe`) is linked against `libatomic`, which the base `actions-runner` image doesn't ship.

## Fix

Add `libatomic1` to the apt install layer. Fixes pnpm-based CI (e.g. `negsoft-n8n-node`) across every repo routed to these runners.

Surfaced by enthus-appdev/negsoft-n8n-node#280.