### PR TITLE
build: bake gcc and make into the runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/actions/actions-runner:2.336.0
 # The fingerprint allowlist pins the apt trust anchor to exactly GitHub's published signing keys.
 RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
-    sudo apt install -y curl wget rsync gnupg libatomic1 && \
+    sudo apt install -y curl wget rsync gnupg libatomic1 gcc make && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
     # Primary-key fingerprints, trust-on-first-use from the keyring served by cli.github.com
     # on 2026-07-16 (GitHub publishes only the keyring URL, not fingerprints). Detects future

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Based on [`ghcr.io/actions/actions-runner`](https://github.com/actions/runner), 
 - `wget` — HTTP/FTP downloader
 - `rsync` — fast file transfer and sync
 - `gh` — GitHub CLI (expected by actions such as `fgrosse/go-coverage-report`; preinstalled on GitHub-hosted runners)
+- `gcc` — C compiler, required by `go test -race` (the race detector links the cgo-based ThreadSanitizer runtime); preinstalled on GitHub-hosted runners
+- `make` — build tool expected by many `make`-driven CI jobs; preinstalled on GitHub-hosted runners
 
 See [`Dockerfile`](Dockerfile) for the exact build definition.
 


### PR DESCRIPTION
## What

Adds `gcc` and `make` to the packages baked into the runner image.

## Why

Per enthus-appdev/warden#608: downstream Go CI runs `go test -race`, which links the cgo-based ThreadSanitizer runtime and therefore needs a host C compiler. The lean upstream `actions-runner` image ships no `gcc`, so the Test job apt-updates + installs it **on every run** (tens of seconds, uncached). The Build & vet job has the identical workaround for `make`.

Baking both into the image removes that per-run cost across all repos using this runner. The downstream "Ensure …" steps stay as cheap fail-loud guards (they exit 0 immediately when the tool is present).

Closes enthus-appdev/warden#608