### PR TITLE
build: bake test system deps into the runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM ghcr.io/actions/actions-runner:2.336.0
 # The fingerprint allowlist pins the apt trust anchor to exactly GitHub's published signing keys.
 RUN sudo rm -rf /etc/apt/sources.list.d/temp.list && \
     sudo apt update -y && \
-    sudo apt install -y curl wget rsync gnupg libatomic1 gcc make && \
+    sudo apt install -y curl wget rsync gnupg libatomic1 gcc make \
+        xz-utils fonts-dejavu fonts-dejavu-extra ffmpeg && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg && \
     # Primary-key fingerprints, trust-on-first-use from the keyring served by cli.github.com
     # on 2026-07-16 (GitHub publishes only the keyring URL, not fingerprints). Detects future


### PR DESCRIPTION
Bakes `xz-utils`, `fonts-dejavu`, `fonts-dejavu-extra` and `ffmpeg` into the runner image.

negsoft-api's Go Test job apt-installs these on every run ([workflow step](https://github.com/enthus-appdev/negsoft-api/blob/master/.github/workflows/go.yml)); baking them in removes the per-run apt cost. Companion PR in negsoft-api makes that step skip packages that are already present.

Note: ffmpeg and its codec deps add a few hundred MB to the image.